### PR TITLE
Add way to override flag env var names

### DIFF
--- a/flagenv.go
+++ b/flagenv.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"sync"
 )
 
 // Specify a prefix for environment variables.
@@ -25,6 +26,8 @@ func contains(list []*flag.Flag, f *flag.Flag) bool {
 // ParseSet parses the given flagset. The specified prefix will be applied to
 // the environment variable names.
 func ParseSet(prefix string, set *flag.FlagSet) error {
+	mu.Lock()
+	defer mu.Unlock()
 	var explicit []*flag.Flag
 	var all []*flag.Flag
 	set.Visit(func(f *flag.Flag) {
@@ -38,16 +41,31 @@ func ParseSet(prefix string, set *flag.FlagSet) error {
 		}
 		all = append(all, f)
 		if !contains(explicit, f) {
-			name := strings.Replace(f.Name, ".", "_", -1)
-			name = strings.Replace(name, "-", "_", -1)
+			defaultName := strings.Replace(f.Name, ".", "_", -1)
+			defaultName = strings.Replace(defaultName, "-", "_", -1)
 			if prefix != "" {
-				name = prefix + name
+				defaultName = prefix + defaultName
 			}
-			name = strings.ToUpper(name)
-			val := os.Getenv(name)
-			if val != "" {
-				if ferr := f.Value.Set(val); ferr != nil {
-					err = fmt.Errorf("failed to set flag %q with value %q", f.Name, val)
+			defaultName = strings.ToUpper(defaultName)
+			envNames := []string{defaultName}
+			if setNames, ok := names[f.Name]; ok {
+				envNames = []string{}
+			set:
+				for _, v := range setNames {
+					if v == "" {
+						envNames = append(envNames, defaultName)
+						continue set
+					}
+					envNames = append(envNames, v)
+				}
+			}
+			for _, v := range envNames {
+				val := os.Getenv(v)
+				if val != "" {
+					if ferr := f.Value.Set(val); ferr != nil {
+						err = fmt.Errorf("failed to set flag %q with value %q", f.Name, val)
+					}
+					return
 				}
 			}
 		}
@@ -64,4 +82,24 @@ func Parse() {
 	if err := ParseSet(Prefix, flag.CommandLine); err != nil {
 		log.Fatalln(err)
 	}
+}
+
+var (
+	names = make(map[string][]string, 0)
+	mu    sync.Mutex
+)
+
+// SetNames replaces automatically generated environment variables for a
+// specific flag and supports multiple names for a flag. Environment variable
+// prefixes are ignored for manually specified names. If an emtpy string is
+// given as an envName argument it will be replaced with the default generated
+// environment variable name.
+func SetNames(flagName string, envName ...string) {
+	mu.Lock()
+	defer mu.Unlock()
+	if len(envName) == 0 {
+		delete(names, flagName)
+		return
+	}
+	names[flagName] = envName
 }

--- a/flagenv_test.go
+++ b/flagenv_test.go
@@ -80,3 +80,25 @@ func TestExplicitAreIgnored(t *testing.T) {
 func TestGlobalParse(t *testing.T) {
 	flagenv.Parse()
 }
+
+func TestSetNames(t *testing.T) {
+	const name = "TestSetNames"
+	os.Setenv(named(name, "names"), "default")
+	os.Setenv("NAME", "name")
+	os.Unsetenv("NOT")
+	for _, testdata := range [][]string{
+		[]string{"name", "NOT", "NAME", ""},
+		[]string{"default", named(name, "names")},
+		[]string{"name", "NAME", ""},
+		[]string{"default", "", "NAME"},
+		[]string{"", "NOT"},
+	} {
+		flagenv.SetNames("names", testdata[1:]...)
+		s := flag.NewFlagSet(name, flag.PanicOnError)
+
+		fooActual := s.String("names", "", "")
+		ensure.Nil(t, flagenv.ParseSet(name, s))
+		ensure.DeepEqual(t, *fooActual, testdata[0])
+	}
+
+}


### PR DESCRIPTION
This is good.. I use this package a lot but it seems like I also work around this limit for a lot of applications where a few flags needs to be able to select from one or more variable..  AWS_ACCESS_KEY_ID is a usual example.

I'm not sure if SetNames is a good method name, I want a reaction before spending more time thinking about language.. 