### PR TITLE
Append environment variable name to flag usage

### DIFF
--- a/flagenv.go
+++ b/flagenv.go
@@ -50,6 +50,7 @@ func ParseSet(prefix string, set *flag.FlagSet) error {
 					err = fmt.Errorf("failed to set flag %q with value %q", f.Name, val)
 				}
 			}
+			f.Usage += fmt.Sprintf(" [env %v]", name)
 		}
 	})
 	return err


### PR DESCRIPTION
Hi!

I think that will be useful for people like ops, who prefers to see help instead of looking at source code to determine env prefix. Format is the same as in lib jessevdk/go-flags.

Example (prefix: test):
```
Usage of test:
  -batch int
    	Number of messages for one transaction. [env TEST_BATCH] (default 100)
```